### PR TITLE
Implement minimal store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# Launch Screen Assets
+# Рыбацкое Дело
 
-You can customize the launch screen with your own desired assets by replacing the image files in this directory.
+Минималистичное Flutter-приложение для оптовой продажи снеков и напитков. Приложение содержит каталог товаров и корзину с оформлением заказа.
 
-You can also do it by opening your Flutter project's Xcode project with `open ios/Runner.xcworkspace`, selecting `Runner/Assets.xcassets` in the Project Navigator and dropping in the desired images.
+## Запуск
+
+```
+flutter run
+```

--- a/lib/data/items.dart
+++ b/lib/data/items.dart
@@ -1,0 +1,14 @@
+import '../models/item.dart';
+
+const items = [
+  Item(id: '1', name: 'Сухарики чесночные', description: 'К хрустящему пиву', price: 50),
+  Item(id: '2', name: 'Арахис соленый', description: 'Жареный арахис', price: 80),
+  Item(id: '3', name: 'Фисташки', description: 'Очищенные', price: 120),
+  Item(id: '4', name: 'Креветки сушеные', description: 'Отличная закуска', price: 150),
+  Item(id: '5', name: 'Чипсы картофельные', description: 'С солью', price: 70),
+  Item(id: '6', name: 'Кальмары сушеные', description: 'К пиву', price: 130),
+  Item(id: '7', name: 'Пиво светлое', description: '0.5 л', price: 90),
+  Item(id: '8', name: 'Пиво тёмное', description: '0.5 л', price: 95),
+  Item(id: '9', name: 'Сидр яблочный', description: '0.5 л', price: 85),
+  Item(id: '10', name: 'Рыбные чипсы', description: 'Из трески', price: 110),
+];

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,0 +1,8 @@
+class Item {
+  final String id;
+  final String name;
+  final String description;
+  final double price;
+
+  const Item({required this.id, required this.name, required this.description, required this.price});
+}

--- a/lib/screens/cart_page.dart
+++ b/lib/screens/cart_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../models/item.dart';
+
+class CartPage extends StatefulWidget {
+  const CartPage({super.key});
+
+  static final Map<Item, int> cartItems = {};
+
+  @override
+  State<CartPage> createState() => _CartPageState();
+}
+
+class _CartPageState extends State<CartPage> {
+  Map<Item, int> get _items => CartPage.cartItems;
+
+  double get _total => _items.entries.fold(0, (sum, e) => sum + e.key.price * e.value);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Корзина')),
+      body: _items.isEmpty
+          ? const Center(child: Text('Корзина пуста'))
+          : Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    children: _items.entries.map((entry) {
+                      final item = entry.key;
+                      final count = entry.value;
+                      return ListTile(
+                        leading: Image.asset('assets/logo.jpg', width: 50),
+                        title: Text(item.name),
+                        subtitle: Text('${item.price.toStringAsFixed(0)} руб. x $count'),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.remove_circle_outline),
+                          onPressed: () {
+                            setState(() {
+                              if (count > 1) {
+                                _items[item] = count - 1;
+                              } else {
+                                _items.remove(item);
+                              }
+                            });
+                          },
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    children: [
+                      Text('Итого: ${_total.toStringAsFixed(0)} руб.'),
+                      const SizedBox(height: 8),
+                      ElevatedButton(
+                        onPressed: () {
+                          setState(() {
+                            _items.clear();
+                          });
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Заказ оформлен!')),
+                          );
+                        },
+                        child: const Text('Оформить заказ'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/screens/catalog_page.dart
+++ b/lib/screens/catalog_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import '../data/items.dart';
+import '../models/item.dart';
+import 'cart_page.dart';
+
+class CatalogPage extends StatefulWidget {
+  const CatalogPage({super.key});
+
+  @override
+  State<CatalogPage> createState() => _CatalogPageState();
+}
+
+class _CatalogPageState extends State<CatalogPage> {
+  final Map<Item, int> _cart = CartPage.cartItems;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Каталог')),
+      body: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return ListTile(
+            leading: Image.asset('assets/logo.jpg', width: 50),
+            title: Text(item.name),
+            subtitle: Text('${item.price.toStringAsFixed(0)} руб.'),
+            trailing: IconButton(
+              icon: const Icon(Icons.add_shopping_cart),
+              onPressed: () {
+                setState(() {
+                  _cart.update(item, (value) => value + 1, ifAbsent: () => 1);
+                });
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Добавлено в корзину')),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Рыбацкое Дело')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Image.asset('assets/logo.jpg', width: 150),
+            const SizedBox(height: 16),
+            const Text(
+              'Оптовая торговля снеками и пивом',
+              style: TextStyle(fontSize: 18),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'home_page.dart';
+import 'catalog_page.dart';
+import 'cart_page.dart';
+
+class MainScreen extends StatefulWidget {
+  const MainScreen({super.key});
+
+  @override
+  State<MainScreen> createState() => _MainScreenState();
+}
+
+class _MainScreenState extends State<MainScreen> {
+  int _currentIndex = 0;
+  final _pages = const [HomePage(), CatalogPage(), CartPage()];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_currentIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) => setState(() => _currentIndex = index),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Главная'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Каталог'),
+          BottomNavigationBarItem(icon: Icon(Icons.shopping_cart), label: 'Корзина'),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement main screens with bottom navigation
- add home, catalog, and cart pages
- provide sample items data
- document launching the new store app

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c605a994832d91409ffbf7e701ac